### PR TITLE
add MANIFEST.in to fix conda build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include shiny_validate/check *
+recursive-include shiny_validate/distjs *


### PR DESCRIPTION
I'd like to add py-shiny-validate to conda-forge, but conda-build fails because it doesn't include the `check` and `distjs` directories in the build. Adding a `MANIFEST.in` file should fix this.

