### PR TITLE
Add argument for list of input IDs that should trigger re-validation when they change

### DIFF
--- a/shiny_validate/distjs/index.js
+++ b/shiny_validate/distjs/index.js
@@ -3188,12 +3188,10 @@
     if (window.Shiny) {
       Shiny.addCustomMessageHandler("validation-jcheng5", function(message) {
         var boundInputsMap = getBoundInputsMap();
-
         for (var _i = 0, _Object$entries = Object.entries(message); _i < _Object$entries.length; _i++) {
           var _Object$entries$_i = _slicedToArray(_Object$entries[_i], 2), key = _Object$entries$_i[0], value = _Object$entries$_i[1];
           var input = boundInputsMap.get(key);
           if (!input) {
-
             // re-attempt a few times with increasing backoff
             (function(currentKey, currentValue) {
               let retries = 0;
@@ -3226,10 +3224,8 @@
                   setTimeout(attemptValidation, nextRetryDelay);
                 }
               }
-
               setTimeout(attemptValidation, initialDelay);
             })(key, value);
-
             continue;
           }
 

--- a/shiny_validate/distjs/index.js
+++ b/shiny_validate/distjs/index.js
@@ -3188,7 +3188,7 @@
     if (window.Shiny) {
       Shiny.addCustomMessageHandler("validation-jcheng5", function(message) {
         var boundInputsMap = getBoundInputsMap();
-        
+
         for (var _i = 0, _Object$entries = Object.entries(message); _i < _Object$entries.length; _i++) {
           var _Object$entries$_i = _slicedToArray(_Object$entries[_i], 2), key = _Object$entries$_i[0], value = _Object$entries$_i[1];
           var input = boundInputsMap.get(key);
@@ -3199,11 +3199,11 @@
               let retries = 0;
               const maxRetries = 5;
               const initialDelay = 50;
-          
+
               function attemptValidation() {
                 var attemptNumber = retries + 1;
                 var nextRetryDelay = initialDelay * Math.pow(1.4, retries);
-                
+
                 // check if element exists in DOM
                 var elementById = document.getElementById(currentKey);
                 if (!elementById) {
@@ -3214,7 +3214,7 @@
                 // try to get current bound inputs
                 var currentBoundInputsMap = getBoundInputsMap();
                 var currentInputFromMap = currentBoundInputsMap.get(currentKey);
-          
+
                 if (currentInputFromMap && currentInputFromMap.el && currentInputFromMap.binding) {
                   if (currentValue === null) {
                     clearInvalid4(currentInputFromMap.el, currentInputFromMap.binding, currentInputFromMap.id);
@@ -3226,13 +3226,13 @@
                   setTimeout(attemptValidation, nextRetryDelay);
                 }
               }
-              
+
               setTimeout(attemptValidation, initialDelay); 
             })(key, value);
-            
+
             continue; 
           }
-          
+
           // Original logic if input was found immediately
           if (value === null) {
             clearInvalid4(input.el, input.binding, input.id);

--- a/shiny_validate/distjs/index.js
+++ b/shiny_validate/distjs/index.js
@@ -3188,13 +3188,52 @@
     if (window.Shiny) {
       Shiny.addCustomMessageHandler("validation-jcheng5", function(message) {
         var boundInputsMap = getBoundInputsMap();
+        
         for (var _i = 0, _Object$entries = Object.entries(message); _i < _Object$entries.length; _i++) {
           var _Object$entries$_i = _slicedToArray(_Object$entries[_i], 2), key = _Object$entries$_i[0], value = _Object$entries$_i[1];
           var input = boundInputsMap.get(key);
           if (!input) {
-            console.warn("Couldn't perform validation update on input with id '" + key + "': input not found");
-            continue;
+
+            // re-attempt a few times with increasing backoff
+            (function(currentKey, currentValue) {
+              let retries = 0;
+              const maxRetries = 5;
+              const initialDelay = 50;
+          
+              function attemptValidation() {
+                var attemptNumber = retries + 1;
+                var nextRetryDelay = initialDelay * Math.pow(1.4, retries);
+                
+                // check if element exists in DOM
+                var elementById = document.getElementById(currentKey);
+                if (!elementById) {
+                    // no longer exists in DOM; stop retries
+                    return;
+                }
+
+                // try to get current bound inputs
+                var currentBoundInputsMap = getBoundInputsMap();
+                var currentInputFromMap = currentBoundInputsMap.get(currentKey);
+          
+                if (currentInputFromMap && currentInputFromMap.el && currentInputFromMap.binding) {
+                  if (currentValue === null) {
+                    clearInvalid4(currentInputFromMap.el, currentInputFromMap.binding, currentInputFromMap.id);
+                  } else {
+                    setInvalid4(currentInputFromMap.el, currentInputFromMap.binding, currentInputFromMap.id, currentValue);
+                  }
+                } else if (retries < maxRetries) {
+                  retries++;
+                  setTimeout(attemptValidation, nextRetryDelay);
+                }
+              }
+              
+              setTimeout(attemptValidation, initialDelay); 
+            })(key, value);
+            
+            continue; 
           }
+          
+          // Original logic if input was found immediately
           if (value === null) {
             clearInvalid4(input.el, input.binding, input.id);
           } else {

--- a/shiny_validate/distjs/index.js
+++ b/shiny_validate/distjs/index.js
@@ -3227,10 +3227,10 @@
                 }
               }
 
-              setTimeout(attemptValidation, initialDelay); 
+              setTimeout(attemptValidation, initialDelay);
             })(key, value);
 
-            continue; 
+            continue;
           }
 
           // Original logic if input was found immediately

--- a/shiny_validate/validator.py
+++ b/shiny_validate/validator.py
@@ -1,5 +1,6 @@
 from shiny import reactive, ui, Session
 from shiny.session import session_context
+from shiny.types import SilentException
 from .deps import html_deps
 from typing import Optional, Callable
 import datetime
@@ -41,7 +42,18 @@ class InputValidator:
         self.__validator_infos: reactive.Value[
             dict[str, InputValidator]
         ] = reactive.Value({})
-        self.__retritter_on: list[str] = retrigger_on or []
+        # `retrigger_on` is a list of input IDs that should trigger a re-validation when
+        # they change
+        if retrigger_on is None:
+            retrigger_on = []
+        elif isinstance(retrigger_on, str):
+            retrigger_on = [retrigger_on]
+        elif not (
+            isinstance(retrigger_on, list)
+            and all(isinstance(item, str) for item in retrigger_on)
+        ):
+            raise ValueError("`retrigger_on` must be a string or a list of strings")
+        self.__retrigger_on: list[str] = retrigger_on or []
 
         ui.insert_ui(
             html_deps,
@@ -105,41 +117,25 @@ class InputValidator:
 
                 @reactive.Effect(priority=self.__priority)
                 async def observer():
-                    # Try to access ALL available inputs to create dependencies
-                    # This ensures we react to any input that might control dynamic rendering
-                    try:
-                        # Get all input IDs that currently exist
-                        all_input_ids = []
-
-                        for control_element_id in self.__retritter_on:
-                            try:
-                                self.__session.input[control_element_id]()
-                                all_input_ids.append(control_element_id)
-                            except:
-                                pass
-
-                    except Exception:
-                        pass
-
-                    # Check if our rule inputs exist
-                    with reactive.isolate():
-                        rules = self.__rules.get()
-
-                    should_validate = True
-                    for input_id in rules.keys():
-                        clean_id = (
-                            input_id.split("-")[-1] if "-" in input_id else input_id
-                        )
+                    # try to access the re-trigger inputs to create reactive
+                    # dependencies (i.e. make sure this function is re-run when any of
+                    # the elements in `self.__retrigger_on` changes)
+                    controls_present = False
+                    for control_element_id in self.__retrigger_on:
                         try:
-                            self.__session.input[clean_id]()
-                        except:
-                            should_validate = False
-                            break
+                            self.__session.input[control_element_id]()
+                            # a control element is present which means that the UI / DOM
+                            # could have changed (and we should give it some time to
+                            # settle before validating below)
+                            controls_present = True
+                        except SilentException:
+                            pass
 
-                    if should_validate:
-                        results = self.validate()
-                    else:
-                        results = {}
+                    if controls_present:
+                        # wait a bit to let the UI settle down
+                        await asyncio.sleep(0.05)
+
+                    results = self.validate()
 
                     await self.__session.send_custom_message(
                         "validation-jcheng5", results

--- a/shiny_validate/validator.py
+++ b/shiny_validate/validator.py
@@ -28,6 +28,7 @@ class InputValidator:
     def __init__(
         self,
         priority=1000,
+        retrigger_on: Optional[list[str]] = None,
     ):
         self.__session = require_active_session(get_current_session())
         self.__priority: int = priority
@@ -40,6 +41,7 @@ class InputValidator:
         self.__validator_infos: reactive.Value[
             dict[str, InputValidator]
         ] = reactive.Value({})
+        self.__retritter_on: list[str] = retrigger_on or []
 
         ui.insert_ui(
             html_deps,
@@ -109,24 +111,10 @@ class InputValidator:
                         # Get all input IDs that currently exist
                         all_input_ids = []
 
-                        # Common control input patterns
-                        potential_controls = [
-                            "checkbox",
-                            "show_input",
-                            "toggle",
-                            "enable",
-                            "show",
-                            "display",
-                            "visible",
-                            "render",
-                            "dynamic",
-                            "conditional",
-                        ]
-
-                        for control_name in potential_controls:
+                        for control_element_id in self.__retritter_on:
                             try:
-                                self.__session.input[control_name]()
-                                all_input_ids.append(control_name)
+                                self.__session.input[control_element_id]()
+                                all_input_ids.append(control_element_id)
                             except:
                                 pass
 

--- a/shiny_validate/validator.py
+++ b/shiny_validate/validator.py
@@ -103,7 +103,56 @@ class InputValidator:
 
                 @reactive.Effect(priority=self.__priority)
                 async def observer():
-                    results = self.validate()
+                    # Try to access ALL available inputs to create dependencies
+                    # This ensures we react to any input that might control dynamic rendering
+                    try:
+                        # Get all input IDs that currently exist
+                        all_input_ids = []
+
+                        # Common control input patterns
+                        potential_controls = [
+                            "checkbox",
+                            "show_input",
+                            "toggle",
+                            "enable",
+                            "show",
+                            "display",
+                            "visible",
+                            "render",
+                            "dynamic",
+                            "conditional",
+                        ]
+
+                        for control_name in potential_controls:
+                            try:
+                                self.__session.input[control_name]()
+                                all_input_ids.append(control_name)
+                            except:
+                                pass
+
+                    except Exception:
+                        pass
+
+                    # Check if our rule inputs exist
+                    with reactive.isolate():
+                        rules = self.__rules.get()
+
+                    should_validate = True
+                    for input_id in rules.keys():
+                        clean_id = (
+                            input_id.split("-")[-1] if "-" in input_id else input_id
+                        )
+                        try:
+                            self.__session.input[clean_id]()
+                        except:
+                            should_validate = False
+                            break
+
+                    if should_validate:
+                        results = self.validate()
+                    else:
+                        results = {}
+
                     await self.__session.send_custom_message(
                         "validation-jcheng5", results
                     )


### PR DESCRIPTION
The problem of #20 is that in dynamic UI elements can disappear and reappear, but the reappearance doesn't trigger `self.validate()`.

This adds `retrigger_on` to `InputValidator.__init__()`. Users can pass a list of input IDs that then trigger `self.validate()` when one of the inputs changes.

I'm sure there is a better way to fix #20 (e.g. by detecting whether the DOM changed and re-validating then), but I didn't manage to get that working properly.

Any input is highly welcome!